### PR TITLE
Fix some crashes and enable warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,10 @@ INCLUDES 	=
 ASM_FLAGS 		= -mcpu=i486 -march=i486
 ASM_FLAGS_386 	= -mcpu=i386 -march=i386
 LDFLAGS 			=
-CFLAGS 			= -mcpu=i486 -march=i486 -fomit-frame-pointer -ffast-math #-O2
-CFLAGS_386		= -mcpu=i386 -march=i386 -fomit-frame-pointer -ffast-math #-O2
+WARNINGS		= -Wall -Werror
+OPT			= -fomit-frame-pointer -ffast-math #-O2
+CFLAGS 			= -mcpu=i486 -march=i486 $(WARNINGS) $(OPT)
+CFLAGS_386		= -mcpu=i386 -march=i386 $(WARNINGS) $(OPT)
 CFLAGS_DEBUG		= -g
 LDSCRIPT 		=
 OCFLAGS			=

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ $(TARGET):  $(OBJFILES)
 	copy $(TARGET) $(DEST)
 
 bmp.o: bmp.c
-	gcc.exe $(CFLAGS) -c bmp.c bmp.o
+	gcc.exe $(CFLAGS) -c bmp.c -o bmp.o
 	
 data.o: data.c
 	gcc.exe $(CFLAGS) -c data.c -o data.o

--- a/bmp.c
+++ b/bmp.c
@@ -35,11 +35,10 @@ int bmp_ReadImage(FILE *bmp_image, bmpdata_t *bmpdata, unsigned char header, uns
 		fclose(f);
 	*/
 	
-	unsigned char	*bmp_ptr, *bmp_ptr_old;	// Represents which row of pixels we are reading at any time
+	unsigned char	*bmp_ptr;	// Represents which row of pixels we are reading at any time
 	int 				i;			// A loop counter
 	int				status;		// Generic status for calls from fread/fseek etc.
-	unsigned char 	pixel;		// A single pixel
-	unsigned char	r,g,b,a;
+	unsigned char	r,g,b;
 
 	if (header){
 		// Seek to dataoffset position in header
@@ -402,8 +401,6 @@ int bmp_ReadFont(FILE *bmp_image, bmpdata_t *bmpdata, fontdata_t *fontdata, unsi
 	int height_chars;
 	int row_bytepos;
 	int i;
-	char b;
-	unsigned char *p_dest, *p_src;
 	
 	if (header){
 		// Extract bmp header

--- a/data.c
+++ b/data.c
@@ -344,7 +344,6 @@ int getIni(config_t *config, int verbose){
 	
 	int status;
 	char my_drive;
-	char my_drive_letter;
 	char my_dir[DIR_BUFFER_SIZE];
 	char my_path[DIR_BUFFER_SIZE];
 	

--- a/data.c
+++ b/data.c
@@ -19,6 +19,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <dos.h>
+#include <unistd.h>
 
 #include "ini.h"
 #ifndef __HAS_DATA

--- a/data.c
+++ b/data.c
@@ -397,7 +397,7 @@ int getImageList(launchdat_t *launchdat, imagefile_t *imagefile){
 		p = strtok(buffer, ",; ");
 		while (p != NULL){
 			if (DATA_VERBOSE){
-				printf("%s.%d\t Extracted image filename [%s], %d len\n", __FILE__, __LINE__, p, strlen(p));
+				printf("%s.%d\t Extracted image filename [%s], %ld len\n", __FILE__, __LINE__, p, strlen(p));
 			}
 			found++;
 			imagefile = getLastImage(imagefile);

--- a/filter.c
+++ b/filter.c
@@ -26,10 +26,14 @@
 #include "filter.h"
 #include "ui.h"
 
+static int qsort_strcmp(const void *lhs, const void *rhs) {
+	return strcmp(lhs, rhs);
+}
+
 int sortFilterKeys(state_t *state, int items){
 	// Sort the list of filter keys by name
 	
-	qsort(state->filter_strings, items, MAX_STRING_SIZE, strcmp);
+	qsort(state->filter_strings, items, MAX_STRING_SIZE, qsort_strcmp);
 	return FILTER_OK;
 }
 

--- a/filter.h
+++ b/filter.h
@@ -30,7 +30,7 @@
 #define FILTER_ERR		-1		// Failure returncode
 
 // Function prototypes
-int filter_GetGenre(state_t *state, gamedata_t *gamedata);
+int filter_GetGenres(state_t *state, gamedata_t *gamedata);
 int filter_GetSeries(state_t *state, gamedata_t *gamedata);
 int filter_None(state_t *state, gamedata_t *gamedata);
 int filter_Genre(state_t *state, gamedata_t *gamedata);

--- a/fstools.c
+++ b/fstools.c
@@ -109,10 +109,10 @@ int isDir(char *path){
 	dir = opendir(path);
 	if (dir != NULL){
 		dir_type = 1;
+		closedir(dir);
 	} else {
 		dir_type = 0;	
 	}
-	closedir(dir);
 	return dir_type;
 }
 

--- a/fstools.c
+++ b/fstools.c
@@ -204,7 +204,7 @@ int findDirs(char *path, gamedata_t *gamedata, int startnum, config_t *config){
 			dir = opendir(path);
 			if (dir != NULL){
 				// Read an entry for the directory entry
-				while (de = readdir(dir)){
+				while ((de = readdir(dir)) != NULL){
 					// Skip any names that are "." and ".."
 					if (strcmp(de->d_name, ".") != 0 && strcmp(de->d_name, "..") != 0){
 						// Only process entries that are of type DT_DIR (e.g. sub-directory names)						

--- a/fstools.c
+++ b/fstools.c
@@ -18,7 +18,9 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
+#include <dos.h>
 #include <dirent.h>
+#include <unistd.h>
 
 #ifndef __HAS_DATA
 #include "data.h"

--- a/fstools.c
+++ b/fstools.c
@@ -144,8 +144,7 @@ int findDirs(char *path, gamedata_t *gamedata, int startnum, config_t *config){
 	// gamedata: An instance of the linked-list of game data
 	// startnum: The starting number to tag each found 'game' with the next auto-incrementing ID
 	
-	char drive, old_drive;
-	char drive_letter, old_drive_letter;
+	unsigned int old_drive;
 	char status;
 	int go;
 	int found;
@@ -180,7 +179,7 @@ int findDirs(char *path, gamedata_t *gamedata, int startnum, config_t *config){
 	}
 	
 	/* save curdrive */
-	_dos_getdrive(old_drive);
+	_dos_getdrive(&old_drive);
 	if (old_drive < 0){
 		printf("%s.%d\t Unable to save current drive [status:%d]\n", __FILE__, __LINE__, old_drive);
 		return -1;
@@ -261,7 +260,7 @@ int findDirs(char *path, gamedata_t *gamedata, int startnum, config_t *config){
 	}
 	
 	/* reload current drive and directory */
-	_dos_setdrive(old_drive);
+	_dos_setdrive(old_drive, &old_drive);
 	status = chdir(old_dir_buffer);
 	if (status != 0){
 		printf("%s.%d\t Unable to restore directory [status:%d\n", __FILE__, __LINE__, status);

--- a/fstools.h
+++ b/fstools.h
@@ -34,6 +34,7 @@
 int 		dirFromPath(char *path, char *buffer);
 int 		dirHasData(char *path);
 int 		drvLetterToNum(char drive_letter);
+char		drvLetterFromPath(char *path);
 char		drvNumToLetter(int drive_number);
 int 		findDirs(char *path, gamedata_t *gamedata, int startnum, config_t *config);
 int 		isDir(char *path);

--- a/gfx.c
+++ b/gfx.c
@@ -186,7 +186,7 @@ void gfx_Flip(){
 	// Copy a buffer of GFX_ROWS * GFX_COLS bytes to
 	// the active VRAM framebuffer for display.
 	
-	movedata(_my_ds(), vram_buffer, vram_dpmi_selector, 0, (GFX_ROWS * GFX_COLS));
+	movedata(_my_ds(), (unsigned)vram_buffer, vram_dpmi_selector, 0, (GFX_ROWS * GFX_COLS));
 }
 
 int gfx_GetXYaddr(int x, int y){

--- a/gfx.c
+++ b/gfx.c
@@ -33,6 +33,11 @@
 #define __HAS_BMP
 #endif
 
+static unsigned char	*vram;				// Pointer to a location in the local graphics buffer
+static unsigned char	vram_buffer[(GFX_ROW_SIZE * GFX_COL_SIZE)];
+static __dpmi_meminfo	vram_dpmi;			// DPMI descriptor for far-memory location of framebuffer
+static int				vram_dpmi_selector;	// Memory region selector handle
+
 static int gfx_DPMI();
 static int gfx_HasMemoryHole();
 

--- a/gfx.c
+++ b/gfx.c
@@ -22,6 +22,8 @@
 #include <dos.h>
 #include <go32.h>
 #include <dpmi.h>
+#include <sys/nearptr.h>
+#include <sys/farptr.h>
 
 #include "gfx.h"
 #include "pegc.h"
@@ -30,6 +32,9 @@
 #include "bmp.h"
 #define __HAS_BMP
 #endif
+
+static int gfx_DPMI();
+static int gfx_HasMemoryHole();
 
 int gfx_Init(){
 	// Initialise graphics to a set of configured defaults

--- a/gfx.c
+++ b/gfx.c
@@ -193,7 +193,6 @@ int gfx_GetXYaddr(int x, int y){
 	// Turn a screen x/y coordinate into an offset into a vram buffer
 	
 	unsigned int addr;
-	unsigned short row;
 	
 	addr = 0x00;
 	addr += GFX_ROW_SIZE * y;
@@ -215,11 +214,10 @@ int gfx_Bitmap(int x, int y, bmpdata_t *bmpdata){
 	//
 	// Bitmaps wider or taller than the screen are UNSUPPORTED
 	
-	int row, col;			//  x and y position counters
+	int row;			//  x position counter
 	int start_addr;		// The first pixel
 	int width_bytes;		// Number of bytes in one row of the image
 	int skip_cols;			// Skip first or last pixels of a row if the image is partially offscreen
-	int skip_bytes;
 	int skip_rows;		// Skip this number of rows if the image is patially offscreen
 	int total_rows	;		// Total number of rows to read in clip mode
 	unsigned char *ptr;	// Pointer to current location in bmp pixel buffer
@@ -549,7 +547,7 @@ int gfx_Puts(int x, int y, fontdata_t *fontdata, char *c){
 	unsigned int	row_offset;
 	unsigned char	font_symbol;
 	unsigned char	font_row;
-	unsigned char	i, w;
+	unsigned char	i;
 	unsigned char	pos;
 	unsigned char	*src, *dst;
 	

--- a/gfx.c
+++ b/gfx.c
@@ -569,7 +569,7 @@ int gfx_Puts(int x, int y, fontdata_t *fontdata, char *c){
 	vram = vram_buffer + start_offset;
 	
 	if (GFX_VERBOSE){
-		printf("%s.%d\t Displaying string: [%s] at vram offset 0x%x\n", __FILE__, __LINE__, c, vram);
+		printf("%s.%d\t Displaying string: [%s] at vram offset 0x%x\n", __FILE__, __LINE__, c, (unsigned)vram);
 		printf("%s.%d\t Displaying string: [%s] at screen co-ords %d,%d\n", __FILE__, __LINE__, c, x, y);
 	}
 		

--- a/gfx.h
+++ b/gfx.h
@@ -61,3 +61,4 @@ int		gfx_GetXYaddr(int x, int y);
 int		gfx_Init();
 void		gfx_TextOff();
 void		gfx_TextOn();
+int		gfx_Puts(int x, int y, fontdata_t *fontdata, char *c);

--- a/gfx.h
+++ b/gfx.h
@@ -41,11 +41,6 @@
 #define GFX_TEXT_OK           		-252 // Output of text data ok
 #define GFX_TEXT_INVALID      		-251 // Attempted output of an unsupported font glyph (too wide, too heigh, etc)
 
-unsigned char	*vram;				// Pointer to a location in the local graphics buffer
-unsigned char	vram_buffer[(GFX_ROW_SIZE * GFX_COL_SIZE)];
-__dpmi_meminfo	vram_dpmi;			// DPMI descriptor for far-memory location of framebuffer
-int				vram_dpmi_selector;	// Memory region selector handle
-
 /* **************************** */
 /* Function prototypes */
 /* **************************** */

--- a/input.c
+++ b/input.c
@@ -18,6 +18,7 @@
 #include <stdio.h>
 #include <pc.h>
 #include <dos.h>
+#include <libc/pc9800.h>
 
 #include "input.h"
 

--- a/main.c
+++ b/main.c
@@ -18,6 +18,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <conio.h>
+#include <unistd.h>
 
 #ifndef __HAS_DATA
 #include "data.h"
@@ -414,7 +416,7 @@ int main() {
 							gamedata = gamedata->next;
 					}
 					gamedata = gamedata_head;
-					close(savefile);
+					fclose(savefile);
 			}
 	} else {
 			ui_ProgressMessage("Not saving game list...");

--- a/main.c
+++ b/main.c
@@ -1046,6 +1046,7 @@ int main() {
 						}
 						imagefile = (imagefile_t *) malloc(sizeof(imagefile_t));
 						imagefile->next = NULL;
+						imagefile->prev = NULL;
 						imagefile_head = imagefile;
 						status = getImageList(launchdat, imagefile);
 						if (status > 0){

--- a/main.c
+++ b/main.c
@@ -54,7 +54,6 @@ int main() {
 	int scrape_dirs;						// NUmber of directories being scraped
 	int scrape_progress_chunk_size;			// Size of progress bar increase per directory being scraped
 	int progress;							// Progress bar percentage
-	int super;								// Supervisor mode flag
 	int found, found_tmp;					// Number of gamedirs/games found
 	int verbose;							// Controls output of additional logging/text
 	int status;								// Generic function return status variable
@@ -66,7 +65,6 @@ int main() {
 	
 	state_t *state = NULL;
 	bmpdata_t *screenshot_bmp = NULL;	
-	bmpstate_t *screenshot_bmp_state = NULL;	
 	gamedata_t *gamedata = NULL;			// An initial gamedata record for the first game directory we read
 	gamedata_t *gamedata_head = NULL;		// Constant pointer to the start of the gamedata list
 	launchdat_t *launchdat = NULL;			// When a single game is selected, we attempt to load its metadata file from disk

--- a/palette.c
+++ b/palette.c
@@ -26,6 +26,11 @@
 #include "pegc.h"
 #include "palette.h"
 
+
+static unsigned int free_palettes_used;			// Current number of palette entries used
+static unsigned int reserved_palettes_used;		// Current number of palette entries used
+
+
 static int pal_BMPRemap(bmpdata_t *bmpdata);
 
 int pal_BMP2Palette(bmpdata_t *bmpdata, int reserved){

--- a/palette.c
+++ b/palette.c
@@ -26,6 +26,8 @@
 #include "pegc.h"
 #include "palette.h"
 
+static int pal_BMPRemap(bmpdata_t *bmpdata);
+
 int pal_BMP2Palette(bmpdata_t *bmpdata, int reserved){
 	// Set palette entries based on a specific bmpdata structure
 	// restricted == 1 if we are setting the 32 reserved colours of the user interface

--- a/palette.c
+++ b/palette.c
@@ -104,9 +104,8 @@ int pal_BMPRemap(bmpdata_t *bmpdata){
 
 	unsigned char *px;
 	unsigned char c;
-	int i;
 	int pos;
-	int px_remapped, colours_remapped, remapped;
+	int px_remapped, colours_remapped;
 	
 	px_remapped = 0;
 	colours_remapped = 0;

--- a/palette.h
+++ b/palette.h
@@ -57,3 +57,4 @@ int 		pal_BMP2Palette(bmpdata_t *bmpdata, int reserved);
 void 	pal_ResetAll();
 void 	pal_ResetFree();
 void 	pal_Set(unsigned char idx, unsigned char r, unsigned char g, unsigned char b);
+void	pal_SetUI();

--- a/palette.h
+++ b/palette.h
@@ -49,10 +49,6 @@
 #define PALETTE_UI_15			PALETTES_FREE + PALETTES_RESERVED + 15
 
 
-unsigned int free_palettes_used;			// Current number of palette entries used
-unsigned int reserved_palettes_used;		// Current number of palette entries used
-
-
 int 		pal_BMP2Palette(bmpdata_t *bmpdata, int reserved);
 void 	pal_ResetAll();
 void 	pal_ResetFree();

--- a/ui.c
+++ b/ui.c
@@ -990,7 +990,7 @@ int ui_UpdateInfoPane(state_t *state, gamedata_t *gamedata, launchdat_t *launchd
 				sprintf(info_year, "N/A");
 				sprintf(info_company, " N/A");
 				sprintf(info_genre, "N/A");
-				sprintf(info_series, "");
+				sprintf(info_series, "N/A");
 				sprintf(info_path, " %s", state->selected_game->path);
 			} else {
 				// ======================

--- a/ui.c
+++ b/ui.c
@@ -248,7 +248,6 @@ int ui_DrawFilterPopup(state_t *state, int toggle){
 	// Draw a page of filter choices for the user to select
 	
 	int i;
-	int status;
 	
 	// Draw drop-shadow
 	gfx_BoxFillTranslucent(40, 50, GFX_COLS - 30, GFX_ROWS - 20, PALETTE_UI_DGREY);
@@ -345,8 +344,6 @@ int ui_DrawInfoBox(){
 int	ui_DrawLaunchPopup(state_t *state, gamedata_t *gamedata, launchdat_t *launchdat, int toggle){
 	// Draw the popup window that lets us select from the main or alternate start file
 	// in order to launch a game
-	
-	int status;	
 	
 	// Draw drop-shadow
 	gfx_BoxFillTranslucent(ui_launch_popup_xpos + 10, ui_launch_popup_ypos + 10, ui_launch_popup_xpos + 10 + ui_launch_popup_width, ui_launch_popup_ypos + 10 + ui_launch_popup_height, PALETTE_UI_DGREY);
@@ -933,7 +930,6 @@ int ui_UpdateInfoPane(state_t *state, gamedata_t *gamedata, launchdat_t *launchd
 	// Clear text on load
 	// snprintf instead of sprintf to limit string sizes
 	
-	int			status;
 	char		status_msg[64];		// Message buffer for anything needing to be printed onscreen
 	char		info_name[64];
 	char		info_year[8];
@@ -943,8 +939,6 @@ int ui_UpdateInfoPane(state_t *state, gamedata_t *gamedata, launchdat_t *launchd
 	char		info_series[32];
 	
 	gamedata_t	*gamedata_head;	// Pointer to the start of the gamedata list, so we can restore it
-	gamedata_t	*selected_game;	// Gamedata object for the currently selected line
-	//launchdat_t	*launchdat;		// Metadata object representing the launch.dat file for this game
 	
 	// Store gamedata head
 	gamedata_head = gamedata;

--- a/ui.c
+++ b/ui.c
@@ -1003,7 +1003,7 @@ int ui_UpdateInfoPane(state_t *state, gamedata_t *gamedata, launchdat_t *launchd
 					printf("%s.%d\t Info - start file: [%s]\n", __FILE__, __LINE__, launchdat->start);
 					printf("%s.%d\t Info - alt_start file: [%s]\n", __FILE__, __LINE__, launchdat->alt_start);
 					printf("%s.%d\t Info - midi: [%d]\n", __FILE__, __LINE__, launchdat->midi);
-					printf("%s.%d\t Info - midi serial: [%s]\n", __FILE__, __LINE__, launchdat->midi_serial);
+					printf("%s.%d\t Info - midi serial: [%d]\n", __FILE__, __LINE__, launchdat->midi_serial);
 				}
 				
 				gfx_Bitmap(ui_checkbox_has_metadata_xpos, ui_checkbox_has_metadata_ypos, ui_checkbox_bmp);

--- a/ui.h
+++ b/ui.h
@@ -194,6 +194,7 @@ void	ui_Close();
 int		ui_DrawInfoBox();
 int		ui_DrawConfirmPopup(state_t *state, gamedata_t *gamedata, launchdat_t *launchdat);
 int		ui_DrawFilterPrePopup(state_t *state, int toggle);
+int		ui_DrawFilterPopup(state_t *state, int toggle);
 int		ui_DrawLaunchPopup(state_t *state, gamedata_t *gamedata, launchdat_t *launchdat, int toggle);
 int		ui_DrawMainWindow();
 int		ui_DrawSplash();


### PR DESCRIPTION
I used your launcher to learn a bit about the PC-98's graphics stack and encountered a few issues when trying to run it, so I had a go at fixing them up. After fixing them I also enabled basic warnings and fixed up what GCC found. See individual commits for more details.